### PR TITLE
 Update action to node16.

### DIFF
--- a/passthrough-action-envs/action.yml
+++ b/passthrough-action-envs/action.yml
@@ -3,7 +3,7 @@ description: |
   Passes through some environmental variables not available in inline steps.
 author: lhwdev
 runs:
-  using: "node12" # ~~no Deno?~~
+  using: "node16" # ~~no Deno?~~
   main: "action.js"
 branding:
   icon: activity


### PR DESCRIPTION
Following the guidance in https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/